### PR TITLE
CLX sequence classifier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## New Features
 
 ## Improvements
+- PR #303 CLX sequence classifier
 
 ## Bug Fixes
 

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -24,6 +24,9 @@ Analytics
 .. autoclass:: clx.analytics.model.rnn_classifier.RNNClassifier
     :members:
 
+.. autoclass:: clx.analytics.sequence_classifier.SequenceClassifier
+    :members:
+
 .. automodule:: clx.analytics.stats
     :members:
 

--- a/examples/streamz/python/phishing_detection.py
+++ b/examples/streamz/python/phishing_detection.py
@@ -39,7 +39,7 @@ def inference(messages):
     
     result_size = df.shape[0]
     print("Processing batch size: " + str(result_size))
-    pred, prob = worker.data["phish_detect"].predict(df["stream"])
+    pred, prob = worker.data["seq_classifier"].predict(df["stream"])
     results_gdf = cudf.DataFrame({"pred": pred, "prob": prob})
     torch.cuda.empty_cache()
     gc.collect()
@@ -74,15 +74,15 @@ def worker_init():
     from clx.analytics.phishing_detector import PhishingDetector
 
     worker = dask.distributed.get_worker()
-    phish_detect = PhishingDetector()
+    seq_classifier = SequenceClassifier()
     print(
         "Initializing Dask worker: "
         + str(worker)
         + " with phishing detection model. Model File: "
         + str(args.model)
     )
-    phish_detect.init_model(args.model)
-    worker.data["phish_detect"] = phish_detect
+    seq_classifier.init_model(args.model)
+    worker.data["seq_classifier"] = seq_classifier
     print("Successfully initialized dask worker " + str(worker))
 
 

--- a/notebooks/cybert/cybert_example_training.ipynb
+++ b/notebooks/cybert/cybert_example_training.ipynb
@@ -170,28 +170,28 @@
        "  </thead>\n",
        "  <tbody>\n",
        "    <tr>\n",
-       "      <th>523</th>\n",
+       "      <th>583</th>\n",
        "      <td>&lt;NA&gt;</td>\n",
        "      <td>&lt;NA&gt;</td>\n",
-       "      <td>41.75.96.130 - - [06/Dec/2016:16:00:03 +0100] ...</td>\n",
-       "      <td>41.75.96.130</td>\n",
+       "      <td>100.1.14.108 - - [30/Sep/2019:22:52:31 +0200] ...</td>\n",
+       "      <td>100.1.14.108</td>\n",
        "      <td>-</td>\n",
        "      <td>-</td>\n",
-       "      <td>http://almhuette-raith.at/administrator/index.php</td>\n",
-       "      <td>Mozilla/5.0 (Windows NT 6.1; WOW64; rv:17.0) G...</td>\n",
-       "      <td>Firefox</td>\n",
-       "      <td>17.0</td>\n",
+       "      <td>-</td>\n",
+       "      <td>Python/3.7 aiohttp/3.6.1</td>\n",
+       "      <td>Python/3.7 aiohttp</td>\n",
+       "      <td>3.6.1</td>\n",
        "      <td>...</td>\n",
        "      <td>&lt;NA&gt;</td>\n",
-       "      <td>4494</td>\n",
-       "      <td>200.0</td>\n",
-       "      <td>[06/Dec/2016:16:00:03 +0100]</td>\n",
-       "      <td>1.481040e+12</td>\n",
-       "      <td>2016-12-06T16:00:03</td>\n",
-       "      <td>1.481036e+12</td>\n",
-       "      <td>2016-12-06T16:00:03+01:00</td>\n",
-       "      <td>1.481036e+12</td>\n",
-       "      <td>2016-12-06T15:00:03+00:00</td>\n",
+       "      <td>219</td>\n",
+       "      <td>404.0</td>\n",
+       "      <td>[30/Sep/2019:22:52:31 +0200]</td>\n",
+       "      <td>1.569884e+12</td>\n",
+       "      <td>2019-09-30T22:52:31</td>\n",
+       "      <td>1.569877e+12</td>\n",
+       "      <td>2019-09-30T22:52:31+02:00</td>\n",
+       "      <td>1.569877e+12</td>\n",
+       "      <td>2019-09-30T20:52:31+00:00</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
@@ -200,40 +200,34 @@
       ],
       "text/plain": [
        "    error_level error_message  \\\n",
-       "523        <NA>          <NA>   \n",
+       "583        <NA>          <NA>   \n",
        "\n",
        "                                                   raw   remote_host  \\\n",
-       "523  41.75.96.130 - - [06/Dec/2016:16:00:03 +0100] ...  41.75.96.130   \n",
+       "583  100.1.14.108 - - [30/Sep/2019:22:52:31 +0200] ...  100.1.14.108   \n",
        "\n",
-       "    remote_logname remote_user  \\\n",
-       "523              -           -   \n",
+       "    remote_logname remote_user request_header_referer  \\\n",
+       "583              -           -                      -   \n",
        "\n",
-       "                                request_header_referer  \\\n",
-       "523  http://almhuette-raith.at/administrator/index.php   \n",
-       "\n",
-       "                             request_header_user_agent  \\\n",
-       "523  Mozilla/5.0 (Windows NT 6.1; WOW64; rv:17.0) G...   \n",
-       "\n",
-       "    request_header_user_agent__browser__family  \\\n",
-       "523                                    Firefox   \n",
+       "    request_header_user_agent request_header_user_agent__browser__family  \\\n",
+       "583  Python/3.7 aiohttp/3.6.1                         Python/3.7 aiohttp   \n",
        "\n",
        "    request_header_user_agent__browser__version_string  ...  \\\n",
-       "523                                               17.0  ...   \n",
+       "583                                              3.6.1  ...   \n",
        "\n",
        "     request_url_username response_bytes_clf status  \\\n",
-       "523                  <NA>               4494  200.0   \n",
+       "583                  <NA>                219  404.0   \n",
        "\n",
        "                    time_received time_received_datetimeobj  \\\n",
-       "523  [06/Dec/2016:16:00:03 +0100]              1.481040e+12   \n",
+       "583  [30/Sep/2019:22:52:31 +0200]              1.569884e+12   \n",
        "\n",
        "     time_received_isoformat time_received_tz_datetimeobj  \\\n",
-       "523      2016-12-06T16:00:03                 1.481036e+12   \n",
+       "583      2019-09-30T22:52:31                 1.569877e+12   \n",
        "\n",
        "     time_received_tz_isoformat time_received_utc_datetimeobj  \\\n",
-       "523   2016-12-06T16:00:03+01:00                  1.481036e+12   \n",
+       "583   2019-09-30T22:52:31+02:00                  1.569877e+12   \n",
        "\n",
        "     time_received_utc_isoformat  \n",
-       "523    2016-12-06T15:00:03+00:00  \n",
+       "583    2019-09-30T20:52:31+00:00  \n",
        "\n",
        "[1 rows x 37 columns]"
       ]
@@ -358,7 +352,6 @@
     "        words = cudf.Series(log.split())\n",
     "        words_size = len(words)\n",
     "        subword_counts = words.str.subword_tokenize(\"resources/bert-base-cased-hash.txt\", 10000, 10000,\\\n",
-    "                                                    max_num_strings=words_size,max_num_chars=10000,\\\n",
     "                                                    max_rows_tensor=words_size,\\\n",
     "                                                    do_lower=False, do_truncate=False)[2].reshape(words_size, 3)[:,2]\n",
     "        for i, tag in enumerate(tags):\n",
@@ -426,7 +419,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "{'[PAD]': 0, 'request_header_referer': 1, 'request_url': 2, 'response_bytes_clf': 3, 'request_method': 4, 'remote_host': 5, 'time_received': 6, 'error_message': 7, 'request_header_user_agent': 8, 'error_level': 9, 'other': 10, 'X': 11}\n"
+      "{'[PAD]': 0, 'time_received': 1, 'error_level': 2, 'error_message': 3, 'request_header_user_agent': 4, 'request_header_referer': 5, 'request_url': 6, 'request_method': 7, 'remote_host': 8, 'response_bytes_clf': 9, 'other': 10, 'X': 11}\n"
      ]
     }
    ],
@@ -477,8 +470,6 @@
     "    num_strings = len(strings)\n",
     "    num_bytes = strings.str.byte_count().sum()\n",
     "    token_ids, mask = strings.str.subword_tokenize(\"resources/bert-base-cased-hash.txt\", 256, 256,\n",
-    "                                                            max_num_strings=num_strings,\n",
-    "                                                            max_num_chars=num_bytes,\n",
     "                                                            max_rows_tensor=num_strings,\n",
     "                                                            do_lower=False, do_truncate=True)[:2]\n",
     "    # convert from cupy to torch tensor using dlpack\n",
@@ -542,11 +533,53 @@
    "metadata": {},
    "outputs": [
     {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "bdaf77c345b44137ab4e8f3d4c570e97",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "HBox(children=(HTML(value='Downloading'), FloatProgress(value=0.0, max=433.0), HTML(value='')))"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "33ad77848c834f7b825d7979a5158173",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "HBox(children=(HTML(value='Downloading'), FloatProgress(value=0.0, max=435779157.0), HTML(value='')))"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n"
+     ]
+    },
+    {
      "name": "stderr",
      "output_type": "stream",
      "text": [
       "Some weights of the model checkpoint at bert-base-cased were not used when initializing BertForTokenClassification: ['cls.predictions.bias', 'cls.predictions.transform.dense.weight', 'cls.predictions.transform.dense.bias', 'cls.predictions.decoder.weight', 'cls.seq_relationship.weight', 'cls.seq_relationship.bias', 'cls.predictions.transform.LayerNorm.weight', 'cls.predictions.transform.LayerNorm.bias']\n",
-      "- This IS expected if you are initializing BertForTokenClassification from the checkpoint of a model trained on another task or with another architecture (e.g. initializing a BertForSequenceClassification model from a BertForPretraining model).\n",
+      "- This IS expected if you are initializing BertForTokenClassification from the checkpoint of a model trained on another task or with another architecture (e.g. initializing a BertForSequenceClassification model from a BertForPreTraining model).\n",
       "- This IS NOT expected if you are initializing BertForTokenClassification from the checkpoint of a model that you expect to be exactly identical (initializing a BertForSequenceClassification model from a BertForSequenceClassification model).\n",
       "Some weights of BertForTokenClassification were not initialized from the model checkpoint at bert-base-cased and are newly initialized: ['classifier.weight', 'classifier.bias']\n",
       "You should probably TRAIN this model on a down-stream task to be able to use it for predictions and inference.\n"
@@ -600,30 +633,30 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "Epoch:  50%|█████     | 1/2 [00:11<00:11, 11.70s/it]"
+      "Epoch:  50%|█████     | 1/2 [00:12<00:12, 12.26s/it]"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Train loss: 0.6094976961612701\n"
+      "Train loss: 0.6824694395065307\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "Epoch: 100%|██████████| 2/2 [00:23<00:00, 11.60s/it]"
+      "Epoch: 100%|██████████| 2/2 [00:24<00:00, 12.21s/it]"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Train loss: 0.03892093759030104\n",
-      "CPU times: user 13.5 s, sys: 9.67 s, total: 23.2 s\n",
-      "Wall time: 23.2 s\n"
+      "Train loss: 0.043616552650928495\n",
+      "CPU times: user 24.4 s, sys: 67.8 ms, total: 24.4 s\n",
+      "Wall time: 24.4 s\n"
      ]
     },
     {
@@ -692,23 +725,23 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "f1 score: 0.990776\n",
-      "Accuracy score: 0.997108\n",
+      "f1 score: 0.997831\n",
+      "Accuracy score: 0.999475\n",
       "                           precision    recall  f1-score   support\n",
       "\n",
-      "                    other     0.9984    0.9967    0.9976       615\n",
-      "              remote_host     1.0000    1.0000    1.0000       181\n",
-      "              request_url     0.9679    1.0000    0.9837       181\n",
-      "request_header_user_agent     0.9704    0.9820    0.9762       167\n",
-      "              error_level     1.0000    1.0000    1.0000        19\n",
+      "                    other     1.0000    1.0000    1.0000       619\n",
       "            time_received     1.0000    1.0000    1.0000       200\n",
-      "            error_message     0.6842    0.6842    0.6842        19\n",
-      "       response_bytes_clf     1.0000    0.9944    0.9972       180\n",
-      "   request_header_referer     1.0000    1.0000    1.0000        95\n",
-      "           request_method     1.0000    1.0000    1.0000       181\n",
+      "              remote_host     1.0000    1.0000    1.0000       182\n",
+      "              request_url     1.0000    1.0000    1.0000       182\n",
+      "           request_method     1.0000    1.0000    1.0000       182\n",
+      "       response_bytes_clf     1.0000    1.0000    1.0000       181\n",
+      "request_header_user_agent     0.9763    0.9880    0.9821       167\n",
+      "   request_header_referer     1.0000    1.0000    1.0000        93\n",
+      "            error_message     1.0000    1.0000    1.0000        18\n",
+      "              error_level     1.0000    1.0000    1.0000        18\n",
       "\n",
-      "                micro avg     0.9881    0.9935    0.9908      1838\n",
-      "                macro avg     0.9903    0.9935    0.9919      1838\n",
+      "                micro avg     0.9967    0.9989    0.9978      1842\n",
+      "                macro avg     0.9979    0.9989    0.9984      1842\n",
       "\n"
      ]
     }

--- a/notebooks/phish_detection/Phishing_Detection_using_Bert_CLX.ipynb
+++ b/notebooks/phish_detection/Phishing_Detection_using_Bert_CLX.ipynb
@@ -67,11 +67,42 @@
    "cell_type": "code",
    "execution_count": 1,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/opt/conda/envs/rapids/lib/python3.7/site-packages/tensorflow/python/framework/dtypes.py:516: FutureWarning: Passing (type, 1) or '1type' as a synonym of type is deprecated; in a future version of numpy, it will be understood as (type, (1,)) / '(1,)type'.\n",
+      "  _np_qint8 = np.dtype([(\"qint8\", np.int8, 1)])\n",
+      "/opt/conda/envs/rapids/lib/python3.7/site-packages/tensorflow/python/framework/dtypes.py:517: FutureWarning: Passing (type, 1) or '1type' as a synonym of type is deprecated; in a future version of numpy, it will be understood as (type, (1,)) / '(1,)type'.\n",
+      "  _np_quint8 = np.dtype([(\"quint8\", np.uint8, 1)])\n",
+      "/opt/conda/envs/rapids/lib/python3.7/site-packages/tensorflow/python/framework/dtypes.py:518: FutureWarning: Passing (type, 1) or '1type' as a synonym of type is deprecated; in a future version of numpy, it will be understood as (type, (1,)) / '(1,)type'.\n",
+      "  _np_qint16 = np.dtype([(\"qint16\", np.int16, 1)])\n",
+      "/opt/conda/envs/rapids/lib/python3.7/site-packages/tensorflow/python/framework/dtypes.py:519: FutureWarning: Passing (type, 1) or '1type' as a synonym of type is deprecated; in a future version of numpy, it will be understood as (type, (1,)) / '(1,)type'.\n",
+      "  _np_quint16 = np.dtype([(\"quint16\", np.uint16, 1)])\n",
+      "/opt/conda/envs/rapids/lib/python3.7/site-packages/tensorflow/python/framework/dtypes.py:520: FutureWarning: Passing (type, 1) or '1type' as a synonym of type is deprecated; in a future version of numpy, it will be understood as (type, (1,)) / '(1,)type'.\n",
+      "  _np_qint32 = np.dtype([(\"qint32\", np.int32, 1)])\n",
+      "/opt/conda/envs/rapids/lib/python3.7/site-packages/tensorflow/python/framework/dtypes.py:525: FutureWarning: Passing (type, 1) or '1type' as a synonym of type is deprecated; in a future version of numpy, it will be understood as (type, (1,)) / '(1,)type'.\n",
+      "  np_resource = np.dtype([(\"resource\", np.ubyte, 1)])\n",
+      "/opt/conda/envs/rapids/lib/python3.7/site-packages/tensorboard/compat/tensorflow_stub/dtypes.py:541: FutureWarning: Passing (type, 1) or '1type' as a synonym of type is deprecated; in a future version of numpy, it will be understood as (type, (1,)) / '(1,)type'.\n",
+      "  _np_qint8 = np.dtype([(\"qint8\", np.int8, 1)])\n",
+      "/opt/conda/envs/rapids/lib/python3.7/site-packages/tensorboard/compat/tensorflow_stub/dtypes.py:542: FutureWarning: Passing (type, 1) or '1type' as a synonym of type is deprecated; in a future version of numpy, it will be understood as (type, (1,)) / '(1,)type'.\n",
+      "  _np_quint8 = np.dtype([(\"quint8\", np.uint8, 1)])\n",
+      "/opt/conda/envs/rapids/lib/python3.7/site-packages/tensorboard/compat/tensorflow_stub/dtypes.py:543: FutureWarning: Passing (type, 1) or '1type' as a synonym of type is deprecated; in a future version of numpy, it will be understood as (type, (1,)) / '(1,)type'.\n",
+      "  _np_qint16 = np.dtype([(\"qint16\", np.int16, 1)])\n",
+      "/opt/conda/envs/rapids/lib/python3.7/site-packages/tensorboard/compat/tensorflow_stub/dtypes.py:544: FutureWarning: Passing (type, 1) or '1type' as a synonym of type is deprecated; in a future version of numpy, it will be understood as (type, (1,)) / '(1,)type'.\n",
+      "  _np_quint16 = np.dtype([(\"quint16\", np.uint16, 1)])\n",
+      "/opt/conda/envs/rapids/lib/python3.7/site-packages/tensorboard/compat/tensorflow_stub/dtypes.py:545: FutureWarning: Passing (type, 1) or '1type' as a synonym of type is deprecated; in a future version of numpy, it will be understood as (type, (1,)) / '(1,)type'.\n",
+      "  _np_qint32 = np.dtype([(\"qint32\", np.int32, 1)])\n",
+      "/opt/conda/envs/rapids/lib/python3.7/site-packages/tensorboard/compat/tensorflow_stub/dtypes.py:550: FutureWarning: Passing (type, 1) or '1type' as a synonym of type is deprecated; in a future version of numpy, it will be understood as (type, (1,)) / '(1,)type'.\n",
+      "  np_resource = np.dtype([(\"resource\", np.ubyte, 1)])\n"
+     ]
+    }
+   ],
    "source": [
     "import cudf;\n",
     "from cuml.preprocessing.model_selection import train_test_split;\n",
-    "from clx.analytics.phishing_detector import PhishingDetector;\n",
+    "from clx.analytics.sequence_classifier import SequenceClassifier;\n",
     "import s3fs;\n",
     "from os import path;"
    ]
@@ -190,53 +221,11 @@
    "metadata": {},
    "outputs": [
     {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "774d2fa14b24490380fb01beb69abb80",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "HBox(children=(FloatProgress(value=0.0, description='Downloading', max=433.0, style=ProgressStyle(description_…"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\n"
-     ]
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "98bd36fa854641c2b775bc2764a9707f",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "HBox(children=(FloatProgress(value=0.0, description='Downloading', max=440473133.0, style=ProgressStyle(descri…"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\n"
-     ]
-    },
-    {
      "name": "stderr",
      "output_type": "stream",
      "text": [
       "Some weights of the model checkpoint at bert-base-uncased were not used when initializing BertForSequenceClassification: ['cls.predictions.bias', 'cls.predictions.transform.dense.weight', 'cls.predictions.transform.dense.bias', 'cls.predictions.decoder.weight', 'cls.seq_relationship.weight', 'cls.seq_relationship.bias', 'cls.predictions.transform.LayerNorm.weight', 'cls.predictions.transform.LayerNorm.bias']\n",
-      "- This IS expected if you are initializing BertForSequenceClassification from the checkpoint of a model trained on another task or with another architecture (e.g. initializing a BertForSequenceClassification model from a BertForPretraining model).\n",
+      "- This IS expected if you are initializing BertForSequenceClassification from the checkpoint of a model trained on another task or with another architecture (e.g. initializing a BertForSequenceClassification model from a BertForPreTraining model).\n",
       "- This IS NOT expected if you are initializing BertForSequenceClassification from the checkpoint of a model that you expect to be exactly identical (initializing a BertForSequenceClassification model from a BertForSequenceClassification model).\n",
       "Some weights of BertForSequenceClassification were not initialized from the model checkpoint at bert-base-uncased and are newly initialized: ['classifier.weight', 'classifier.bias']\n",
       "You should probably TRAIN this model on a down-stream task to be able to use it for predictions and inference.\n"
@@ -244,8 +233,8 @@
     }
    ],
    "source": [
-    "phish_detect = PhishingDetector()\n",
-    "phish_detect.init_model()\n",
+    "seq_classifier = SequenceClassifier()\n",
+    "seq_classifier.init_model(\"bert-base-uncased\")\n",
     "\n",
     "# init_model can also load pre-trained model by passing it model directory path"
    ]
@@ -285,28 +274,16 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "Epoch:   0%|          | 0/1 [00:00<?, ?it/s]"
+      "Epoch:   0%|          | 0/1 [00:00<?, ?it/s]/opt/conda/envs/rapids/lib/python3.7/site-packages/torch/nn/parallel/_functions.py:64: UserWarning: Was asked to gather along dimension 0, but all input tensors were scalars; will instead unsqueeze and return a vector.\n",
+      "  warnings.warn('Was asked to gather along dimension 0, but all '\n",
+      "Epoch: 100%|██████████| 1/1 [00:47<00:00, 47.48s/it]"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Train loss: 0.0781611256509879\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "Epoch: 100%|██████████| 1/1 [00:59<00:00, 59.21s/it]"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Validation Accuracy: 0.9947916666666666\n"
+      "Train loss: 0.20608550182711255\n"
      ]
     },
     {
@@ -315,10 +292,17 @@
      "text": [
       "\n"
      ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Validation Accuracy: 0.9947916666666666\n"
+     ]
     }
    ],
    "source": [
-    "phish_detect.train_model(X_train, y_train, epochs=1)"
+    "seq_classifier.train_model(X_train[\"email\"], y_train, epochs=1)"
    ]
   },
   {
@@ -336,7 +320,7 @@
     {
      "data": {
       "text/plain": [
-       "0.9974853310980721"
+       "0.9953897736797989"
       ]
      },
      "execution_count": 12,
@@ -345,7 +329,7 @@
     }
    ],
    "source": [
-    "phish_detect.evaluate_model(X_test, y_test)"
+    "seq_classifier.evaluate_model(X_test[\"email\"], y_test)"
    ]
   },
   {
@@ -410,28 +394,14 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "Epoch:   0%|          | 0/1 [00:00<?, ?it/s]"
+      "Epoch: 100%|██████████| 1/1 [00:12<00:00, 12.62s/it]"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Train loss: 0.44632136821746826\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "Epoch: 100%|██████████| 1/1 [00:16<00:00, 16.62s/it]"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Validation Accuracy: 0.862348615916955\n"
+      "Train loss: 0.7128496293091413\n"
      ]
     },
     {
@@ -440,10 +410,17 @@
      "text": [
       "\n"
      ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Validation Accuracy: 0.9209558823529411\n"
+     ]
     }
    ],
    "source": [
-    "phish_detect.train_model(X_train, y_train, epochs=1)"
+    "seq_classifier.train_model(X_train[\"email\"], y_train, epochs=1)"
    ]
   },
   {
@@ -461,7 +438,7 @@
     {
      "data": {
       "text/plain": [
-       "0.8366111951588502"
+       "0.9349470499243571"
       ]
      },
      "execution_count": 16,
@@ -470,7 +447,7 @@
     }
    ],
    "source": [
-    "phish_detect.evaluate_model(X_test, y_test)"
+    "seq_classifier.evaluate_model(X_test[\"email\"], y_test)"
    ]
   },
   {
@@ -523,28 +500,14 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "Epoch:   0%|          | 0/1 [00:00<?, ?it/s]"
+      "Epoch: 100%|██████████| 1/1 [00:57<00:00, 57.07s/it]"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Train loss: 0.04908236236842044\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "Epoch: 100%|██████████| 1/1 [01:15<00:00, 75.63s/it]"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Validation Accuracy: 0.9959415584415584\n"
+      "Train loss: 0.11770776656005898\n"
      ]
     },
     {
@@ -553,10 +516,17 @@
      "text": [
       "\n"
      ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Validation Accuracy: 0.9955357142857143\n"
+     ]
     }
    ],
    "source": [
-    "phish_detect.train_model(X_train, y_train, epochs=1)"
+    "seq_classifier.train_model(X_train[\"email\"], y_train, epochs=1)"
    ]
   },
   {
@@ -574,7 +544,7 @@
     {
      "data": {
       "text/plain": [
-       "0.9983585029546946"
+       "0.9947472094550229"
       ]
      },
      "execution_count": 20,
@@ -583,7 +553,7 @@
     }
    ],
    "source": [
-    "phish_detect.evaluate_model(X_test, y_test)"
+    "seq_classifier.evaluate_model(X_test[\"email\"], y_test)"
    ]
   },
   {
@@ -642,28 +612,14 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "Epoch:   0%|          | 0/1 [00:00<?, ?it/s]"
+      "Epoch: 100%|██████████| 1/1 [01:35<00:00, 95.50s/it]"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Train loss: 0.01176047741604328\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "Epoch: 100%|██████████| 1/1 [02:06<00:00, 126.25s/it]"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Validation Accuracy: 0.999261811023622\n"
+      "Train loss: 0.026596252602440914\n"
      ]
     },
     {
@@ -672,10 +628,17 @@
      "text": [
       "\n"
      ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Validation Accuracy: 0.9982775590551181\n"
+     ]
     }
    ],
    "source": [
-    "phish_detect.train_model(X_train, y_train, epochs=1)"
+    "seq_classifier.train_model(X_train[\"email\"], y_train, epochs=1)"
    ]
   },
   {
@@ -693,7 +656,7 @@
     {
      "data": {
       "text/plain": [
-       "0.9988109393579072"
+       "0.9980182322631788"
       ]
      },
      "execution_count": 24,
@@ -702,7 +665,7 @@
     }
    ],
    "source": [
-    "phish_detect.evaluate_model(X_test, y_test)"
+    "seq_classifier.evaluate_model(X_test[\"email\"], y_test)"
    ]
   },
   {

--- a/python/clx/analytics/cybert.py
+++ b/python/clx/analytics/cybert.py
@@ -113,15 +113,12 @@ class Cybert:
         raw_data_col = raw_data_col.str.replace("\\n", " ")
 
         byte_count = raw_data_col.str.byte_count()
-        max_num_chars = byte_count.sum()
         max_rows_tensor = int((byte_count / 120).ceil().sum())
 
         input_ids, att_mask, meta_data = raw_data_col.str.subword_tokenize(
             self._hashpath,
             128,
             116,
-            max_num_strings=len(raw_data_col),
-            max_num_chars=max_num_chars,
             max_rows_tensor=max_rows_tensor,
             do_lower=False,
             do_truncate=False,

--- a/python/clx/tests/test_sequence_classifier.py
+++ b/python/clx/tests/test_sequence_classifier.py
@@ -1,0 +1,74 @@
+# Copyright (c) 2020, NVIDIA CORPORATION.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import random
+from os import path
+
+import cudf
+import torch
+import transformers
+from cuml.preprocessing.model_selection import train_test_split
+from faker import Faker
+
+from clx.analytics.sequence_classifier import SequenceClassifier
+
+sc = SequenceClassifier()
+if torch.cuda.is_available():
+    sc.init_model("bert-base-uncased")
+
+
+def test_train_model():
+    if torch.cuda.is_available():
+        fake = Faker()
+        email_col = [fake.text() for _ in range(200)]
+        label_col = [random.randint(0, 1) for _ in range(200)]
+        emails_gdf = cudf.DataFrame(list(zip(email_col, label_col)), columns=["email", "label"])
+        X_train, X_test, y_train, y_test = train_test_split(
+            emails_gdf, "label", train_size=0.8, random_state=10
+        )
+        sc.train_model(
+            X_train["email"],
+            y_train,
+            learning_rate=3e-5,
+            max_seq_len=128,
+            batch_size=32,
+            epochs=1,
+        )
+        assert isinstance(
+            sc._model.module,
+            transformers.modeling_bert.BertForSequenceClassification,
+        )
+
+
+def test_evaluate_model():
+    if torch.cuda.is_available():
+        X_test = cudf.Series(["email 1", "email 2"])
+        y_test = cudf.Series([0, 0])
+        accuracy = sc.evaluate_model(
+            X_test, y_test, max_seq_len=128, batch_size=32
+        )
+        assert accuracy >= 0.0 and accuracy <= 1.0
+
+
+def test_predict():
+    if torch.cuda.is_available():
+        X_test = cudf.Series(["email 1", "email 2"])
+        preds = sc.predict(X_test, max_seq_len=128)
+        assert preds[0].isin([False, True]).equals(cudf.Series([True, True]))
+
+
+def test_save_model(tmpdir):
+    if torch.cuda.is_available():
+        sc.save_model(tmpdir)
+        assert path.exists(str(tmpdir.join("config.json")))
+        assert path.exists(str(tmpdir.join("pytorch_model.bin")))


### PR DESCRIPTION
* add probabilities, threshold to phish detection

* phishing detection streamz workflow

* use dataparallel for phishing inference

* flake8 style fixes

* update changelog

* use pytorch dataparallel for phish training

* pin transformers to v3.5

* updates from review feedback

* add sequence classifier module

* sequence classifier code/doc updates

* deprecate phishing detector module

* sequence classifier unit tests

* update phishing streamz workflow to use sequence classifier

* update phishing notebook to use sequence classifier

* update changelog

* fix flake8 error

* fixed memory issues with sequence classifier inference

* pytorch empty_cache after seq classifier train and evaluate

* switch seq classifier back to using pytorch dataloader for training

* set seq classifier default batch size to 128 for training

* fix cybert errors from cudf subword_tokenize updates

* flake8 fix

* revert seq classifier default training batch size back to 32

* update cybert training notebook after cudf changes

* remove unused method from sequence classifier

* remove unnecessary memory cleanup from sequence classifier