### PR TITLE
SlashNext API Integration (#328)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # clx 0.18.0 (Date TBD)
 
 ## New Features
+- PR #328 SlashNext API integration
 
 ## Improvements
 - PR #276 Project Flash and gpuCI Scripts Update

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,8 +18,9 @@ RUN source activate rapids && \
     conda install -c pytorch "pytorch=1.7.0" torchvision "cudf_kafka=${RAPIDS_VERSION}" "custreamz=${RAPIDS_VERSION}" "scikit-learn>=0.21" "nodejs>=12" ipywidgets python-confluent-kafka "transformers=4.*" "seqeval=0.0.12" python-whois seaborn requests matplotlib pytest jupyterlab && \
     pip install "git+https://github.com/rapidsai/cudatashader.git" && \
     pip install mockito && \
-    pip install wget
-
+    pip install wget && \
+    pip install "git+https://github.com/slashnext/SlashNext-URL-Analysis-and-Enrichment.git#egg=slashnext-phishing-ir&subdirectory=Python SDK/src"
+    
 RUN source activate rapids \
   && conda install -n rapids jupyterlab-nvdashboard \
   && jupyter labextension install @jupyter-widgets/jupyterlab-manager dask-labextension jupyterlab-nvdashboard

--- a/ci/docs/build.sh
+++ b/ci/docs/build.sh
@@ -35,6 +35,7 @@ conda install --freeze-installed -c rapidsai-nightly -c rapidsai -c nvidia -c py
     "pytorch>=1.7" torchvision "transformers=3.5.*" requests yaml python-confluent-kafka python-whois markdown beautifulsoup4 jq
     
 pip install mockito
+pip install "git+https://github.com/slashnext/SlashNext-URL-Analysis-and-Enrichment.git#egg=slashnext-phishing-ir&subdirectory=Python SDK/src"
 pip install cupy-cuda${CUDA_SHORT}
 
 gpuci_logger "Check versions"

--- a/ci/gpu/build.sh
+++ b/ci/gpu/build.sh
@@ -61,6 +61,7 @@ gpuci_conda_retry install -y -c pytorch -c gwerbin \
 
 gpuci_logger "Install cudatashader"
 pip install "git+https://github.com/rapidsai/cudatashader.git"
+pip install "git+https://github.com/slashnext/SlashNext-URL-Analysis-and-Enrichment.git#egg=slashnext-phishing-ir&subdirectory=Python SDK/src"
 pip install mockito
 pip install wget
 pip install faker

--- a/conda/environments/clx_dev_cuda10.1.yml
+++ b/conda/environments/clx_dev_cuda10.1.yml
@@ -41,5 +41,6 @@ dependencies:
   - "git+https://github.com/dask/dask.git"
   - "git+https://github.com/dask/distributed.git"
   - "git+https://github.com/rapidsai/cudatashader.git"
+  - "git+https://github.com/slashnext/SlashNext-URL-Analysis-and-Enrichment.git#egg=slashnext-phishing-ir&subdirectory=Python SDK/src"
   - wget
   - mockito

--- a/conda/environments/clx_dev_cuda10.2.yml
+++ b/conda/environments/clx_dev_cuda10.2.yml
@@ -41,5 +41,6 @@ dependencies:
   - "git+https://github.com/dask/dask.git"
   - "git+https://github.com/dask/distributed.git"
   - "git+https://github.com/rapidsai/cudatashader.git"
+  - "git+https://github.com/slashnext/SlashNext-URL-Analysis-and-Enrichment.git#egg=slashnext-phishing-ir&subdirectory=Python SDK/src"
   - wget
   - mockito

--- a/conda/environments/clx_dev_cuda11.0.yml
+++ b/conda/environments/clx_dev_cuda11.0.yml
@@ -41,5 +41,6 @@ dependencies:
   - "git+https://github.com/dask/dask.git"
   - "git+https://github.com/dask/distributed.git"
   - "git+https://github.com/rapidsai/cudatashader.git"
+  - "git+https://github.com/slashnext/SlashNext-URL-Analysis-and-Enrichment.git#egg=slashnext-phishing-ir&subdirectory=Python SDK/src"
   - wget
   - mockito

--- a/examples/streamz/Dockerfile
+++ b/examples/streamz/Dockerfile
@@ -68,8 +68,14 @@ RUN source activate rapids && \
     pip install mockito && \
     pip install wget && \
     pip install elasticsearch && \
-    pip install elasticsearch-async
+    pip install elasticsearch-async && \
+    pip install "git+https://github.com/slashnext/SlashNext-URL-Analysis-and-Enrichment.git#egg=slashnext-phishing-ir&subdirectory=Python SDK/src"
 
+# slashnext download and install
+RUN source activate rapids && \
+    git clone https://github.com/slashnext/SlashNext-URL-Analysis-and-Enrichment.git /opt/slashnext && \
+    pip install /opt/slashnext/Python\ SDK/src/
+    
 RUN source activate rapids \
   && conda install -n rapids jupyterlab-nvdashboard \
   && jupyter labextension install @jupyter-widgets/jupyterlab-manager dask-labextension jupyterlab-nvdashboard

--- a/python/clx/osi/slashnext.py
+++ b/python/clx/osi/slashnext.py
@@ -1,0 +1,334 @@
+# Copyright (c) 2021, NVIDIA CORPORATION.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# ref: https://github.com/slashnext/SlashNext-URL-Analysis-and-Enrichment/tree/master/Python%20SDK
+import os
+from SlashNextPhishingIR import SlashNextPhishingIR
+
+
+class SlashNextClient(object):
+    def __init__(
+        self, api_key, snx_ir_workspace, base_url="https://oti.slashnext.cloud/api"
+    ):
+        if api_key is None:
+            raise ValueError("SlashNext API key is None")
+        if snx_ir_workspace is not None:
+            if not os.path.exists(snx_ir_workspace):
+                try:
+                    print("Creating directory {}".format(snx_ir_workspace))
+                    os.makedirs(snx_ir_workspace)
+                except Exception as error:
+                    raise Exception("Error while creating workspace: " + repr(error))
+        self._snx_phishing_ir = SlashNextPhishingIR(snx_ir_workspace)
+        self._snx_phishing_ir.set_conf(api_key=api_key, base_url=base_url)
+
+    @property
+    def conn(self):
+        return self._snx_phishing_ir
+
+    def verify_connection(self):
+        """
+        Verify SlashNext cloud database connection.
+        Examples
+        --------
+        >>> from clx.osi.slashnext import SlashNextClient
+        >>> api_key = 'slashnext_cloud_apikey'
+        >>> snx_ir_workspace_dir = 'snx_ir_workspace'
+        >>> slashnext = SlashNextClient(api_key, snx_ir_workspace_dir)
+        >>> slashnext.verify_connection()
+        Successfully connected to SlashNext cloud.
+        'success'
+        """
+        status, details = self.conn.test()
+        if status == "ok":
+            print("Successfully connected to SlashNext cloud.")
+            return "success"
+        else:
+            raise Exception(
+                "Connection to SlashNext cloud failed due to {}.".format(details)
+            )
+
+    def _execute(self, command):
+        """
+        Execute all SlashNext Phishing Incident Response SDK supported actions/commands.
+        :param command: Query to execute on SlashNext cloud database.
+        :type command: str
+        :return Query response as list.
+        :rtype: list
+        """
+        status, details, responses_list = self.conn.execute(command)
+        if status == "ok":
+            return responses_list
+        else:
+            raise Exception(
+                "Action '{}' execution failed due to {}.".format(command, details)
+            )
+
+    def host_reputation(self, host):
+        """
+        Queries the SlashNext cloud database and retrieves the reputation of a host.
+        :param host: The host to look up in the SlashNext Threat Intelligence database. Can be either a domain name or an IPv4 address.
+        :type host: str
+        :return Query response as list.
+        :rtype: list
+
+        Examples
+        --------
+        >>> from clx.osi.slashnext import SlashNextClient
+        >>> api_key = 'slashnext_cloud_apikey'
+        >>> snx_ir_workspace_dir = 'snx_ir_workspace'
+        >>> slashnext = SlashNextClient(api_key, snx_ir_workspace_dir)
+        >>> response_list = slashnext.host_reputation('google.com')
+        >>> type(response_list[0])
+        <class 'dict'>
+        """
+        command = "slashnext-host-reputation host={}".format(host)
+        try:
+            return self._execute(command)
+        except Exception as error:
+            raise Exception("SlashNext Host Reputation: " + repr(error))
+
+    def host_report(self, host):
+        """
+        Queries the SlashNext cloud database and retrieves a detailed report.
+        :param host: The host to look up in the SlashNext Threat Intelligence database. Can be either a domain name or an IPv4 address.
+        :type host: str
+        :return Query response as list.
+        :rtype: list
+
+        Examples
+        --------
+        >>> from clx.osi.slashnext import SlashNextClient
+        >>> api_key = 'slashnext_cloud_apikey'
+        >>> snx_ir_workspace_dir = 'snx_ir_workspace'
+        >>> slashnext = SlashNextClient(api_key, snx_ir_workspace_dir)
+        >>> response_list = slashnext.host_report('google.com')
+        >>> type(response_list[0])
+        <class 'dict'>
+        """
+        command = "slashnext-host-report host={}".format(host)
+        try:
+            return self._execute(command)
+        except Exception as error:
+            raise Exception("SlashNext Host Report: " + repr(error))
+
+    def host_urls(self, host, limit=10):
+        """
+        Queries the SlashNext cloud database and retrieves a list of all URLs.
+        :param host: The host to look up in the SlashNext Threat Intelligence database, for which to return a list of associated URLs. Can be either a domain name or an IPv4 address.
+        :type host: str
+        :param limit: The maximum number of URL records to fetch. Default is "10".
+        :type limit: int
+        :return Query response as list.
+        :rtype: list
+
+        Examples
+        --------
+        >>> from clx.osi.slashnext import SlashNextClient
+        >>> api_key = 'slashnext_cloud_apikey'
+        >>> snx_ir_workspace_dir = 'snx_ir_workspace'
+        >>> slashnext = SlashNextClient(api_key, snx_ir_workspace_dir)
+        >>> response_list = slashnext.host_urls('google.com', limit=1)
+        >>> type(response_list[0])
+        <class 'dict'>
+        """
+        command = "slashnext-host-urls host={} limit={}".format(host, limit)
+        try:
+            return self._execute(command)
+        except Exception as error:
+            raise Exception("SlashNext Host urls: " + repr(error))
+
+    def url_scan(self, url, extended_info=True):
+        """
+        Perform a real-time URL reputation scan with SlashNext cloud-based SEER threat detection engine.
+        :param url: The URL that needs to be scanned.
+        :type url: str
+        :param extended_info: Whether to download forensics data, such as screenshot, HTML, and rendered text.
+        :type extended_info: boolean
+        :return Query response as list.
+        :rtype: list
+
+        Examples
+        --------
+        >>> from clx.osi.slashnext import SlashNextClient
+        >>> api_key = 'slashnext_cloud_apikey'
+        >>> snx_ir_workspace_dir = 'snx_ir_workspace'
+        >>> slashnext = SlashNextClient(api_key, snx_ir_workspace_dir)
+        >>> response_list = slashnext.url_scan('http://ajeetenterprises.in/js/kbrad/drive/index.php', extended_info=False)
+        >>> type(response_list[0])
+        <class 'dict'>
+        """
+        command = "slashnext-url-scan url={} extended_info={}".format(
+            url, str(extended_info).lower()
+        )
+        try:
+            return self._execute(command)
+        except Exception as error:
+            raise Exception("SlashNext URL Scan: " + repr(error))
+
+    def url_scan_sync(self, url, extended_info=True, timeout=60):
+        """
+        Perform a real-time URL scan with SlashNext cloud-based SEER threat detection engine in a blocking mode.
+        :param url: The URL that needs to be scanned.
+        :type url: str
+        :param extended_info: Whether to download forensics data, such as screenshot, HTML, and rendered text.
+        :type extended_info: boolean
+        :param timeout: A timeout value in seconds. If no timeout value is specified, a default timeout value is 60 seconds.
+        :type timeout: int
+        :return Query response as list.
+        :rtype: list
+
+        Examples
+        --------
+        >>> from clx.osi.slashnext import SlashNextClient
+        >>> api_key = 'slashnext_cloud_apikey'
+        >>> snx_ir_workspace_dir = 'snx_ir_workspace'
+        >>> slashnext = SlashNextClient(api_key, snx_ir_workspace_dir)
+        >>> response_list = slashnext.url_scan_sync('http://ajeetenterprises.in/js/kbrad/drive/index.php', extended_info=False, timeout=10)
+        >>> type(response_list[0])
+        <class 'dict'>
+        """
+        command = "slashnext-url-scan-sync url={} extended_info={} timeout={}".format(
+            url, str(extended_info).lower(), timeout
+        )
+        try:
+            return self._execute(command)
+        except Exception as error:
+            raise Exception("SlashNext URL Scan Sync: " + repr(error))
+
+    def scan_report(self, scanid, extended_info=True):
+        """
+        Retrieve URL scan results against a previous scan request.
+        :param scanid: Scan ID of the scan for which to get the report. Can be retrieved from the "slashnext-url-scan" action or "slashnext-url-scan-sync" action.
+        :type scanid: str
+        :param extended_info: Whether to download forensics data, such as screenshot, HTML, and rendered text.
+        :type extended_info: boolean
+        :return Query response as list.
+        :rtype: list
+
+        Examples
+        --------
+        >>> from clx.osi.slashnext import SlashNextClient
+        >>> api_key = 'slashnext_cloud_apikey'
+        >>> snx_ir_workspace_dir = 'snx_ir_workspace'
+        >>> slashnext = SlashNextClient(api_key, snx_ir_workspace_dir)
+        >>> response_list = slashnext.scan_report('2-ba57-755a7458c8a3', extended_info=False)
+        >>> type(response_list[0])
+        <class 'dict'>
+        """
+        command = "slashnext-scan-report scanid={} extended_info={}".format(
+            scanid, str(extended_info).lower()
+        )
+        try:
+            return self._execute(command)
+        except Exception as error:
+            raise Exception("SlashNext Scan Report: " + repr(error))
+
+    def download_screenshot(self, scanid, resolution="high"):
+        """
+        Downloads a screenshot of a web page against a previous URL scan request.
+        :param scanid: Scan ID of the scan for which to get the report. Can be retrieved from the "slashnext-url-scan" action or "slashnext-url-scan-sync" action.
+        :type scanid: str
+        :param resolution: Resolution of the web page screenshot. Can be "high" or "medium". Default is "high".
+        :type resolution: str
+        :return Query response as list.
+        :rtype: list
+
+        Examples
+        --------
+        >>> from clx.osi.slashnext import SlashNextClient
+        >>> api_key = 'slashnext_cloud_apikey'
+        >>> snx_ir_workspace_dir = 'snx_ir_workspace'
+        >>> slashnext = SlashNextClient(api_key, snx_ir_workspace_dir)
+        >>> response_list = slashnext.download_screenshot('2-ba57-755a7458c8a3')
+        >>> type(response_list[0])
+        <class 'dict'>
+        """
+        command = "slashnext-download-screenshot scanid={} resolution={}".format(
+            scanid, resolution.lower()
+        )
+        try:
+            return self._execute(command)
+        except Exception as error:
+            raise Exception("SlashNext Download Screenshot: " + repr(error))
+
+    def download_html(self, scanid):
+        """
+        Downloads a web page HTML against a previous URL scan request.
+        :param scanid: Scan ID of the scan for which to get the report. Can be retrieved from the "slashnext-url-scan" action or "slashnext-url-scan-sync" action.
+        :type scanid: str
+        :return Query response as list.
+        :rtype: list
+
+        Examples
+        --------
+        >>> from clx.osi.slashnext import SlashNextClient
+        >>> api_key = 'slashnext_cloud_apikey'
+        >>> snx_ir_workspace_dir = 'snx_ir_workspace'
+        >>> slashnext = SlashNextClient(api_key, snx_ir_workspace_dir)
+        >>> response_list = slashnext.download_html('2-ba57-755a7458c8a3')
+        >>> type(response_list[0])
+        <class 'dict'>
+        """
+        command = "slashnext-download-html scanid={}".format(scanid)
+        try:
+            return self._execute(command)
+        except Exception as error:
+            raise Exception("SlashNext Download HTML: " + repr(error))
+
+    def download_text(self, scanid):
+        """
+        Downloads the text of a web page against a previous URL scan request.
+        :param scanid: Scan ID of the scan for which to get the report. Can be retrieved from the "slashnext-url-scan" action or "slashnext-url-scan-sync" action.
+        :type scanid: str
+        :return Query response as list.
+        :rtype: list
+
+        Examples
+        --------
+        >>> from clx.osi.slashnext import SlashNextClient
+        >>> api_key = 'slashnext_cloud_apikey'
+        >>> snx_ir_workspace_dir = 'snx_ir_workspace'
+        >>> slashnext = SlashNextClient(api_key, snx_ir_workspace_dir)
+        >>> response_list = slashnext.download_text('2-ba57-755a7458c8a3')
+        >>> type(response_list[0])
+        <class 'dict'>
+        """
+        command = "slashnext-download-text scanid={}".format(scanid)
+        try:
+            return self._execute(command)
+        except Exception as error:
+            raise Exception("SlashNext Download HTML: " + repr(error))
+
+    def api_quota(self):
+        """
+        Find information about your API quota, like current usage, quota left etc.
+        :return Query response as list.
+        :rtype: list
+
+        Examples
+        --------
+        >>> from clx.osi.slashnext import SlashNextClient
+        >>> api_key = 'slashnext_cloud_apikey'
+        >>> snx_ir_workspace_dir = 'snx_ir_workspace'
+        >>> slashnext = SlashNextClient(api_key, snx_ir_workspace_dir)
+        >>> response_list = slashnext.api_quota()
+        >>> type(response_list[0])
+        <class 'dict'>
+        """
+        command = "slashnext-api-quota"
+        try:
+            return self._execute(command)
+        except Exception as error:
+            raise Exception("SlashNext API Quota: " + repr(error))

--- a/python/clx/tests/test_slashnext.py
+++ b/python/clx/tests/test_slashnext.py
@@ -1,0 +1,196 @@
+# Copyright (c) 2021, NVIDIA CORPORATION.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# ref: https://github.com/slashnext/SlashNext-URL-Analysis-and-Enrichment/tree/master/Python%20SDK
+import pytest
+from mockito import when
+from clx.osi.slashnext import SlashNextClient
+
+api_key = "dummy-api-key"
+ok_status = "ok"
+ok_details = "Success"
+
+host_reputation_resp_str = "[{'errorNo': 0, 'errorMsg': 'Success', 'threatData': {'verdict': 'Benign', 'threatStatus': 'N/A', 'threatName': 'N/A', 'threatType': 'N/A', 'firstSeen': '12-10-2018 13:04:17 UTC', 'lastSeen': '01-14-2021 15:29:36 UTC'}}]"
+host_report_resp_str = "[{'errorNo': 0, 'errorMsg': 'Success', 'threatData': {'verdict': 'Benign', 'threatStatus': 'N/A', 'threatName': 'N/A', 'threatType': 'N/A', 'firstSeen': '12-10-2018 13:04:17 UTC', 'lastSeen': '01-14-2021 15:29:36 UTC'}}, {'errorNo': 0, 'errorMsg': 'Success', 'urlDataList': [{'url': 'https://www.google.com/', 'scanId': '988dd47c-0-4ecc-86fc-b7bae139bcca', 'threatData': {'verdict': 'Benign', 'threatStatus': 'N/A', 'threatName': 'N/A', 'threatType': 'N/A', 'firstSeen': '08-27-2019 10:32:19 UTC', 'lastSeen': '08-27-2019 12:34:52 UTC'}}], 'normalizeData': {'normalizeStatus': 0, 'normalizeMessage': ''}}, {'errorNo': 0, 'errorMsg': 'Success', 'scData': {'scBase64': '/9j/4AAQSkZJRgABAQEASABIAAD/2wBDAAMCw+...', 'htmlName': 'Webpage-html', 'htmlContenType': 'html'}}, {'errorNo': 0, 'errorMsg': 'Success', 'textData': {'textBase64': 'V2UndmUgZGV0ZWN0ZWQgeW=', 'textName': 'Webpage-text'}}]"
+api_quota_resp_str = "[{'errorNo': 0, 'errorMsg': 'Success', 'quotaDetails': {'licensedQuota': '1825000', 'remainingQuota': 1824967, 'expiryDate': '2021-12-11', 'isExpired': False, 'pointsConsumptionRate': {'hostReputation': 1, 'hostUrls': 1, 'urlReputation': 1, 'uRLScan': 3, 'uRLScanSync': 3, 'downloadScreenshot': 0, 'downloadText': 0, 'downloadHTML': 0, 'customerApiQuota': 0, 'urlScanWithScanId': 0, 'urlScanSyncWithScanId': 0}, 'consumedAPIDetail': {'hostReputation': 13, 'hostUrls': 8, 'urlReputation': 0, 'uRLScan': 2, 'uRLScanSync': 2, 'downloadScreenshot': 9, 'downloadText': 8, 'downloadHTML': 8, 'customerApiQuota': 37, 'scanReportWithScanId': 1, 'scanSyncReportWithScanId': 0}, 'consumedPointsDetail': {'hostReputation': 13, 'hostUrls': 8, 'urlReputation': 0, 'uRLScan': 6, 'uRLScanSync': 6, 'downloadScreenshot': 0, 'downloadText': 0, 'downloadHTML': 0, 'customerApiQuota': 0, 'scanReportWithScanId': 0, 'scanSyncReportWithScanId': 0}, 'note': 'Your annual API quota will be reset to zero, once either the limit is reached or upon quota expiration date indicated above.'}}]"
+host_urls_resp_str = "[{'errorNo': 0, 'errorMsg': 'Success', 'urlDataList': [{'url': 'https://blueheaventravel.com/vendor/filp/whoops/up/index.php?email=Jackdavis@eureliosollutions.com', 'scanId': 'ace21670-7e20-49f2-ba57-755a7458c8a3', 'threatData': {'verdict': 'Benign', 'threatStatus': 'N/A', 'threatName': 'N/A', 'threatType': 'N/A', 'firstSeen': '01-13-2021 21:04:01 UTC', 'lastSeen': '01-13-2021 21:04:11 UTC'}, 'finalUrl': 'https://blueheaventravel.com/vendor/filp/whoops/up/?email=Jackdavis@eureliosollutions.com'}], 'normalizeData': {'normalizeStatus': 1, 'normalizeMessage': 'Note: Email address specified in the Scanned URL was replaced with a dummy email to protect user privacy.'}}]"
+url_scan_resp_str = "[{'errorNo': 0, 'errorMsg': 'Success', 'urlData': {'url': 'http://ajeetenterprises.in/js/kbrad/drive/index.php', 'scanId': 'e468db1d-6bc0-47af-ab7d-76e4a38b2489', 'threatData': {'verdict': 'Malicious', 'threatStatus': 'Active', 'threatName': 'Fake Login Page', 'threatType': 'Phishing & Social Engineering', 'firstSeen': '12-27-2019 07:45:55 UTC', 'lastSeen': '12-27-2019 07:47:51 UTC'}}, 'normalizeData': {'normalizeStatus': 0, 'normalizeMessage': ''}}]"
+url_scan_sync_resp_str = "[{'errorNo': 0, 'errorMsg': 'Success', 'urlData': {'url': 'http://ajeetenterprises.in/js/kbrad/drive/index.php', 'scanId': 'e468db1d-6bc0-47af-ab7d-76e4a38b2489', 'threatData': {'verdict': 'Malicious', 'threatStatus': 'Active', 'threatName': 'Fake Login Page', 'threatType': 'Phishing & Social Engineering', 'firstSeen': '12-27-2019 07:45:55 UTC', 'lastSeen': '12-27-2019 07:47:51 UTC'}}, 'normalizeData': {'normalizeStatus': 0, 'normalizeMessage': ''}}]"
+scan_report_resp_str = "[{'errorNo': 0, 'errorMsg': 'Success', 'urlData': {'url': 'https://blueheaventravel.com/vendor/filp/whoops/up/index.php?email=Jackdavis@eureliosollutions.com', 'scanId': 'ace21670-7e20-49f2-ba57-755a7458c8a3', 'threatData': {'verdict': 'Benign', 'threatStatus': 'N/A', 'threatName': 'N/A', 'threatType': 'N/A', 'firstSeen': '01-13-2021 21:04:01 UTC', 'lastSeen': '01-13-2021 21:04:11 UTC'}, 'finalUrl': 'https://blueheaventravel.com/vendor/filp/whoops/up/?email=Jackdavis@eureliosollutions.com'}, 'normalizeData': {'normalizeStatus': 1, 'normalizeMessage': 'Note: Email address specified in the Scanned URL was replaced with a dummy email to protect user privacy.'}}]"
+download_screenshot_rsp_str = "[{'errorNo': 0, 'errorMsg': 'Success', 'scData': {'scBase64': '/9j/4AAQSkZJRgABAQEASABIAAD/2wBDAAMCAgICAgMCAgIDAwMDBAYEBAQEBAgGBgUGCQgKCgkICQkKDA8MCgsOCwkJDRENDg8QEBEQCgwSExIQEw8QEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAB//Z', 'scName': 'Webpage-screenshot', 'scContentType': 'jpeg'}}]"
+download_html_rsp_str = "[{'errorNo': 0, 'errorMsg': 'Success', 'scData': {'scBase64': '/9j/4AAQSkZJRgABAQEASABIAAD/2wBDAAMCAgICAgMCAgIDAwMDBAYEBAQEBAgGBgUGCQgKCgkICQkKDA8MCgsOCwkJDRENDg8QEBEQCgwSExIQEw8QEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAB//Z', 'htmlName': 'Webpage-html', 'htmlContenType': 'html'}}]"
+download_text_rsp_str = "[{'errorNo': 0, 'errorMsg': 'Success', 'textData': {'textBase64': 'RW1haWwgU2V0dGluZ3MKSmFja2RhdmlzQGV1cmVsaW9zb2xsdXRpb25zLmNvbQpBY2NvdW50IFZlcmlmaWNhdGlvbgpDb3VudGRvd24gdG8geW91ciBlbWFpbCBzaHV0ZG93bjoKMDE6MTU6MDMKVG8gcHJldmVudCB5b3VyIEVtYWlsIGZyb20gYmVpbmcgc2h1dGRvd24sIFZlcmlmeSB5b3VyIGFjY291bnQgZGV0YWlscyBiZWxvdzoKSmFja2RhdmlzQGV1cmVsaW9zb2xsdXRpb25zLmNvbQoqKiogQWNjb3VudCAvIFNldHRpbmdzIC8gU2VjdXJpdHkgU2V0dGluZ3MgLyBBY2NvdW50IFZlcmlmaWNhdGlvbiA+Pg==', 'textName': 'Webpage-text'}}]"
+
+
+def test_verify_connection(tmpdir):
+    slashnext = SlashNextClient(api_key, tmpdir)
+    when(slashnext.conn).test().thenReturn(("ok", "Success"))
+    assert slashnext.verify_connection() == "success"
+
+
+def test2_verify_connection(tmpdir):
+    slashnext = SlashNextClient(api_key, tmpdir)
+    when(slashnext.conn).test().thenReturn(("error", "Failed"))
+    expected_exception = Exception(
+        "Connection to SlashNext cloud failed due to Failed."
+    )
+    with pytest.raises(Exception) as actual_exception:
+        slashnext.verify_connection()
+        assert actual_exception == expected_exception
+
+
+def test_host_reputation(tmpdir):
+    slashnext = SlashNextClient(api_key, tmpdir)
+    when(slashnext.conn).execute(...).thenReturn(
+        (ok_status, ok_details, eval(host_reputation_resp_str))
+    )
+    host = "google.com"
+    resp_list = slashnext.host_reputation(host)
+    assert resp_list[0]["errorNo"] == 0
+    assert resp_list[0]["errorMsg"] == "Success"
+    assert "threatData" in resp_list[0]
+
+
+def test_host_report(tmpdir):
+    slashnext = SlashNextClient(api_key, tmpdir)
+    when(slashnext.conn).execute(...).thenReturn(
+        (ok_status, ok_details, eval(host_report_resp_str))
+    )
+    host = "google.com"
+    resp_list = slashnext.host_report(host)
+    assert resp_list[0]["errorNo"] == 0
+    assert resp_list[0]["errorMsg"] == "Success"
+    assert "threatData" in resp_list[0]
+    assert resp_list[1]["errorNo"] == 0
+    assert resp_list[1]["errorMsg"] == "Success"
+    assert "urlDataList" in resp_list[1]
+    assert "normalizeData" in resp_list[1]
+
+
+def test_host_urls(tmpdir):
+    slashnext = SlashNextClient(api_key, tmpdir)
+    when(slashnext.conn).execute(...).thenReturn(
+        (ok_status, ok_details, eval(host_urls_resp_str))
+    )
+    host = "blueheaventravel.com"
+    resp_list = slashnext.host_urls(host, limit=1)
+    assert len(resp_list) == 1
+    assert resp_list[0]["errorNo"] == 0
+    assert resp_list[0]["errorMsg"] == "Success"
+    assert "urlDataList" in resp_list[0]
+
+
+def test_url_scan(tmpdir):
+    slashnext = SlashNextClient(api_key, tmpdir)
+    when(slashnext.conn).execute(...).thenReturn(
+        (ok_status, ok_details, eval(url_scan_resp_str))
+    )
+    url = "http://ajeetenterprises.in/js/kbrad/drive/index.php"
+    resp_list = slashnext.url_scan(url, extended_info=False)
+    assert resp_list[0]["errorNo"] == 0
+    assert resp_list[0]["errorMsg"] == "Success"
+    assert "urlData" in resp_list[0]
+
+
+def test_url_scan_sync(tmpdir):
+    slashnext = SlashNextClient(api_key, tmpdir)
+    when(slashnext.conn).execute(...).thenReturn(
+        (ok_status, ok_details, eval(url_scan_sync_resp_str))
+    )
+    url = "http://ajeetenterprises.in/js/kbrad/drive/index.php"
+    resp_list = slashnext.url_scan_sync(url, extended_info=False, timeout=10)
+    assert len(resp_list) == 1
+    assert resp_list[0]["errorNo"] == 0
+    assert resp_list[0]["errorMsg"] == "Success"
+    assert "urlData" in resp_list[0]
+
+
+def test_scan_report(tmpdir):
+    slashnext = SlashNextClient(api_key, tmpdir)
+    when(slashnext.conn).execute(...).thenReturn(
+        (ok_status, ok_details, eval(scan_report_resp_str))
+    )
+    scanid = "ace21670-7e20-49f2-ba57-755a7458c8a3"
+    resp_list = slashnext.scan_report(scanid, extended_info=False)
+    assert len(resp_list) == 1
+    assert resp_list[0]["errorNo"] == 0
+    assert resp_list[0]["errorMsg"] == "Success"
+    assert "urlData" in resp_list[0]
+
+
+def test_download_screenshot(tmpdir):
+    slashnext = SlashNextClient(api_key, tmpdir)
+    when(slashnext.conn).execute(...).thenReturn(
+        (ok_status, ok_details, eval(download_screenshot_rsp_str))
+    )
+    scanid = "ace21670-7e20-49f2-ba57-755a7458c8a3"
+    resp_list = slashnext.download_screenshot(scanid, resolution="medium")
+    assert len(resp_list) == 1
+    assert resp_list[0]["errorNo"] == 0
+    assert resp_list[0]["errorMsg"] == "Success"
+    assert "scData" in resp_list[0]
+    assert resp_list[0]["scData"]["scName"] == "Webpage-screenshot"
+    assert resp_list[0]["scData"]["scContentType"] == "jpeg"
+
+
+def test_download_html(tmpdir):
+    slashnext = SlashNextClient(api_key, tmpdir)
+    when(slashnext.conn).execute(...).thenReturn(
+        (ok_status, ok_details, eval(download_html_rsp_str))
+    )
+    scanid = "ace21670-7e20-49f2-ba57-755a7458c8a3"
+    resp_list = slashnext.download_html(scanid)
+    assert len(resp_list) == 1
+    assert resp_list[0]["errorNo"] == 0
+    assert resp_list[0]["errorMsg"] == "Success"
+    assert "scData" in resp_list[0]
+    assert resp_list[0]["scData"]["htmlName"] == "Webpage-html"
+    assert resp_list[0]["scData"]["htmlContenType"] == "html"
+
+
+def test_download_text(tmpdir):
+    slashnext = SlashNextClient(api_key, tmpdir)
+    when(slashnext.conn).execute(...).thenReturn(
+        (ok_status, ok_details, eval(download_text_rsp_str))
+    )
+    scanid = "ace21670-7e20-49f2-ba57-755a7458c8a3"
+    resp_list = slashnext.scan_report(scanid)
+    assert len(resp_list) == 1
+    assert resp_list[0]["errorNo"] == 0
+    assert resp_list[0]["errorMsg"] == "Success"
+    assert "textData" in resp_list[0]
+    assert resp_list[0]["textData"]["textName"] == "Webpage-text"
+
+
+def test_api_quota(tmpdir):
+    slashnext = SlashNextClient(api_key, tmpdir)
+    when(slashnext.conn).execute(...).thenReturn(
+        (ok_status, ok_details, eval(api_quota_resp_str))
+    )
+    resp_list = slashnext.api_quota()
+    assert resp_list[0]["errorNo"] == 0
+    assert resp_list[0]["errorMsg"] == "Success"
+    assert "quotaDetails" in resp_list[0]
+
+
+def test2_host_reputation(tmpdir):
+    slashnext = SlashNextClient(api_key, tmpdir)
+    when(slashnext.conn).execute(...).thenReturn(("error", "error", []))
+    host = "google.com"
+    expected_exception = Exception(
+        "Action 'slashnext-host-reputation host=google.com execution failed due to error."
+    )
+    with pytest.raises(Exception) as actual_exception:
+        slashnext.host_reputation(host)
+        assert actual_exception == expected_exception


### PR DESCRIPTION
Integrated below SlashNext API's into CLX osi package.
1. slashnext-host-reputation - Queries the SlashNext cloud database and retrieves the reputation of a host.
2. slashnext-host-report - Queries the SlashNext cloud database and retrieves a detailed report.
3. slashnext-host-urls - Queries the SlashNext cloud database and retrieves a list of all URLs.
4. slashnext-url-scan - Perform a real-time URL reputation scan with SlashNext cloud-based SEER threat detection engine.
5. slashnext-url-scan-sync - Perform a real-time URL scan with SlashNext cloud-based SEER threat detection engine in a
blocking mode.
6. slashnext-scan-report - Retrieve URL scan results against a previous scan request.
7. slashnext-download screenshot - Downloads a screenshot of a web page against a previous URL scan request.
8. slashnext-download-html - Downloads a web page HTML against a previous URL scan request.
9. slashnext-download-text - Downloads the text of a web page against a previous URL scan request.
10. slashnext-api-quota - Find information about your API quota, like current usage, quota left etc.

Authors:
  - @bsuryadevara

Approvers:
  - AJ Schmidt (@ajschmidt8)
  - BiancaR (@brhodes10)

URL: https://github.com/rapidsai/clx/pull/328